### PR TITLE
UIBarButtonItem item support

### DIFF
--- a/RKNotificationHub/Base.lproj/Main.storyboard
+++ b/RKNotificationHub/Base.lproj/Main.storyboard
@@ -1,13 +1,14 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6211" systemVersion="14A298i" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="vXZ-lx-hvc">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="7531" systemVersion="14D131" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="ofT-6h-NN0">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6204"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7520"/>
     </dependencies>
     <scenes>
         <!--View Controller-->
         <scene sceneID="ufC-wZ-h7g">
             <objects>
-                <viewController id="vXZ-lx-hvc" customClass="ViewController" customModuleProvider="" sceneMemberID="viewController">
+                <viewController id="vXZ-lx-hvc" customClass="ViewController" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="jyV-Pf-zRb"/>
                         <viewControllerLayoutGuide type="bottom" id="2fi-mo-0CV"/>
@@ -17,9 +18,38 @@
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
                     </view>
+                    <navigationItem key="navigationItem" id="INH-RZ-gQi">
+                        <barButtonItem key="leftBarButtonItem" systemItem="trash" id="ZrS-ss-DO5">
+                            <connections>
+                                <action selector="barButtonPressed:" destination="vXZ-lx-hvc" id="ug5-QR-FiV"/>
+                            </connections>
+                        </barButtonItem>
+                    </navigationItem>
+                    <connections>
+                        <outlet property="barButtonItem" destination="ZrS-ss-DO5" id="t7x-3N-JVO"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="x5A-6p-PRh" sceneMemberID="firstResponder"/>
             </objects>
+            <point key="canvasLocation" x="1117" y="415"/>
+        </scene>
+        <!--Navigation Controller-->
+        <scene sceneID="ids-Zm-Tn4">
+            <objects>
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="ofT-6h-NN0" sceneMemberID="viewController">
+                    <toolbarItems/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="9An-TN-iNR">
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <nil name="viewControllers"/>
+                    <connections>
+                        <segue destination="vXZ-lx-hvc" kind="relationship" relationship="rootViewController" id="leO-M2-1Id"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Emh-T3-q3J" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="334" y="1076"/>
         </scene>
     </scenes>
 </document>

--- a/RKNotificationHub/RKNotificationHub.h
+++ b/RKNotificationHub/RKNotificationHub.h
@@ -38,6 +38,7 @@
 
 //%%% setup
 - (id)initWithView:(UIView *)view;
+- (id)initWithViewBarButtonItem:(UIBarButtonItem *)barButtonItem;
 
 //%%% adjustment methods
 - (void)setView:(UIView *)view andCount:(int)startCount;

--- a/RKNotificationHub/RKNotificationHub.h
+++ b/RKNotificationHub/RKNotificationHub.h
@@ -38,7 +38,7 @@
 
 //%%% setup
 - (id)initWithView:(UIView *)view;
-- (id)initWithViewBarButtonItem:(UIBarButtonItem *)barButtonItem;
+- (id)initWithBarButtonItem:(UIBarButtonItem *)barButtonItem;
 
 //%%% adjustment methods
 - (void)setView:(UIView *)view andCount:(int)startCount;

--- a/RKNotificationHub/RKNotificationHub.m
+++ b/RKNotificationHub/RKNotificationHub.m
@@ -69,6 +69,15 @@ CGFloat kBumpTimeSeconds2 = 0.1;
     return self;
 }
 
+- (id)initWithViewBarButtonItem:(UIBarButtonItem *)barButtonItem
+{
+  self = [self initWithView:[barButtonItem valueForKey:@"view"]];
+  [self scaleCircleSizeBy:0.7];
+  [self moveCircleByX:-5.0 Y:0];
+  
+  return self;
+}
+
 //%%% give this a view and an initial count (0 hides the notification circle)
 // and it will make a hub for you
 - (void)setView:(UIView *)view andCount:(int)startCount

--- a/RKNotificationHub/RKNotificationHub.m
+++ b/RKNotificationHub/RKNotificationHub.m
@@ -69,7 +69,7 @@ CGFloat kBumpTimeSeconds2 = 0.1;
     return self;
 }
 
-- (id)initWithViewBarButtonItem:(UIBarButtonItem *)barButtonItem
+- (id)initWithBarButtonItem:(UIBarButtonItem *)barButtonItem
 {
   self = [self initWithView:[barButtonItem valueForKey:@"view"]];
   [self scaleCircleSizeBy:0.7];

--- a/RKNotificationHub/ViewController.h
+++ b/RKNotificationHub/ViewController.h
@@ -35,6 +35,7 @@
 
 @interface ViewController : UIViewController
 
+- (IBAction)barButtonPressed:(id)sender;
 
 @end
 

--- a/RKNotificationHub/ViewController.m
+++ b/RKNotificationHub/ViewController.m
@@ -11,7 +11,9 @@
 
 @interface ViewController () {
     RKNotificationHub *hub;
+    RKNotificationHub *barHub;
 }
+@property (weak, nonatomic) IBOutlet UIBarButtonItem *barButtonItem;
 
 @end
 
@@ -27,8 +29,16 @@
     hub = [[RKNotificationHub alloc]initWithView:imageView];
     [hub moveCircleByX:-5 Y:5]; // moves the circle five pixels left and 5 down
 //    [hub hideCount]; // uncomment for a blank badge
-    
+  
+    barHub = [[RKNotificationHub alloc] initWithViewBarButtonItem: _barButtonItem];
+  
     [self.view addSubview:imageView];
+}
+
+
+- (IBAction)barButtonPressed:(id)sender {
+  [barHub increment];
+  [barHub pop];
 }
 
 -(void)testIncrement

--- a/RKNotificationHub/ViewController.m
+++ b/RKNotificationHub/ViewController.m
@@ -30,7 +30,7 @@
     [hub moveCircleByX:-5 Y:5]; // moves the circle five pixels left and 5 down
 //    [hub hideCount]; // uncomment for a blank badge
   
-    barHub = [[RKNotificationHub alloc] initWithViewBarButtonItem: _barButtonItem];
+    barHub = [[RKNotificationHub alloc] initWithBarButtonItem: _barButtonItem];
   
     [self.view addSubview:imageView];
 }


### PR DESCRIPTION
Since the `UIBarButtonItem` (in opposite to `UITabBarItem`) does not have a badge count I am proposing this addition to your framework: A convenience initialiser for a `UIBarButtonItem`.

It is actually not a big deal but it took me several hours figuring out how to get the view without loosing build in functionality (like the ability to recognise taps). On top of that I am manipulating the size and position of the badge to fit the bar icon (Feel free to modify this if you don't like my values)

I was considering to change the font of the counter a little bit (because it is getting fairly small), but that would require some more changes.

Let me know what you think (especially since I am not really an Objective-C programmer, feel free to correct my style)

My second commit is adding a Navigation Controller to your example, so you can see what I did. When pressing the icon in the tab bar it should increment the counter animated.