### PR TITLE
Change count to NSUInteger, make local constants static const

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ __Combine Actions!__
 * 1.0.1 cocoapod allows iOS 7.0
 * 1.0.2 added "hideCount", "showCount", and "count" methods, allowing indeterminate badges with no number
 * 1.0.5 added bubble expansion for larger numbers [(gif)](http://i.imgur.com/cpQuShT.gif)
-* 1.0.6 changed count to `NSUInteger`, made local constants `static const`
+* 2.0.0 changed count to `NSUInteger` (removed support for negative counts), made local constants `static const`
 
 ### Areas for Improvements / involvement
 * A mechanism for adding a custom animation

--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@ Code:
 ```
 ``` objc
   -(void)increment;
-  -(void)incrementBy:(int)amount;
+  -(void)incrementBy:(NSUInteger)amount;
   -(void)decrement;
-  -(void)decrementBy:(int)amount;
-  -(void)setCount:(int)newCount; //%%% set to a certain number
+  -(void)decrementBy:(NSUInteger)amount;
+  -(void)setCount:(NSUInteger)newCount; //%%% set to a certain number
 ```
 
 __Combine Actions!__
@@ -73,7 +73,6 @@ __Combine Actions!__
 
 **It isn't incrementing / decrementing properly!**
 * I've written it so that any count < 1 doesn't show up. If you need help customizing this, reach out to me
-* Calling [decrement] will never bring the count below 0, but calling [decrementBy:] or [setCount:] will allow negative values (negative values still won't show up)
 
 **The circle is in a weird place**
 * If you want to resize the circle, use [scaleCircleSizeBy:]. 0.5 will give you half the size, 2 will give you double
@@ -91,6 +90,7 @@ __Combine Actions!__
 * 1.0.1 cocoapod allows iOS 7.0
 * 1.0.2 added "hideCount", "showCount", and "count" methods, allowing indeterminate badges with no number
 * 1.0.5 added bubble expansion for larger numbers [(gif)](http://i.imgur.com/cpQuShT.gif)
+* 1.0.6 changed count to `NSUInteger`, made local constants `static const`
 
 ### Areas for Improvements / involvement
 * A mechanism for adding a custom animation

--- a/RKNotificationHub.podspec
+++ b/RKNotificationHub.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
 #
 
 s.name         = "RKNotificationHub"
-s.version      = "1.0.6"
+s.version      = "2.0.0"
 s.summary      = "iOS: Make any UIView a full fledged notification center"
 
 s.description  = "A simple one line solution to turning adding a notification bubble to any UIView. Easily increment, decrement, an animate the notification, -Notification, -Notification Center, -objectivec, -ios, -iphone, -xcode"

--- a/RKNotificationHub.podspec
+++ b/RKNotificationHub.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
 #
 
 s.name         = "RKNotificationHub"
-s.version      = "1.0.5"
+s.version      = "1.0.6"
 s.summary      = "iOS: Make any UIView a full fledged notification center"
 
 s.description  = "A simple one line solution to turning adding a notification bubble to any UIView. Easily increment, decrement, an animate the notification, -Notification, -Notification Center, -objectivec, -ios, -iphone, -xcode"

--- a/RKNotificationHub/RKNotificationHub.h
+++ b/RKNotificationHub/RKNotificationHub.h
@@ -34,6 +34,11 @@
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
+/**
+ *  The default diameter of the notification hub view.
+ */
+FOUNDATION_EXPORT CGFloat const RKNotificationHubDefaultDiameter;
+
 @interface RKNotificationHub : NSObject
 
 //%%% setup

--- a/RKNotificationHub/RKNotificationHub.h
+++ b/RKNotificationHub/RKNotificationHub.h
@@ -46,20 +46,19 @@ FOUNDATION_EXPORT CGFloat const RKNotificationHubDefaultDiameter;
 - (id)initWithBarButtonItem:(UIBarButtonItem *)barButtonItem;
 
 //%%% adjustment methods
-- (void)setView:(UIView *)view andCount:(int)startCount;
+- (void)setView:(UIView *)view andCount:(NSUInteger)startCount;
 - (void)setCircleAtFrame:(CGRect)frame;
 - (void)setCircleColor:(UIColor*)circleColor labelColor:(UIColor*)labelColor;
 - (void)moveCircleByX:(CGFloat)x Y:(CGFloat)y;
 - (void)scaleCircleSizeBy:(CGFloat)scale;
-- (void)setCountLabelFont:(UIFont *)font;
+@property (nonatomic, strong) UIFont *countLabelFont;
 
 //%%% changing the count
 - (void)increment;
-- (void)incrementBy:(int)amount;
+- (void)incrementBy:(NSUInteger)amount;
 - (void)decrement;
-- (void)decrementBy:(int)amount;
-- (void)setCount:(int)newCount;
-- (int)count; // returns the count (treat as get method)
+- (void)decrementBy:(NSUInteger)amount;
+@property (nonatomic, assign) NSUInteger count;
 
 //%%% hiding / showing the count
 - (void)hideCount;

--- a/RKNotificationHub/RKNotificationHub.m
+++ b/RKNotificationHub/RKNotificationHub.m
@@ -188,6 +188,7 @@ static CGFloat const kBumpTimeSeconds2 = 0.1;
 {
     if (amount >= self.count) {
         self.count = 0;
+        return;
     }
     self.count -= amount;
 }

--- a/RKNotificationHub/RKNotificationHub.m
+++ b/RKNotificationHub/RKNotificationHub.m
@@ -45,7 +45,6 @@ static CGFloat const kBumpTimeSeconds2 = 0.1;
 
 
 @implementation RKNotificationHub {
-    int count;
     int curOrderMagnitude;
     UILabel *countLabel;
     RKView *redCircle;
@@ -80,7 +79,7 @@ static CGFloat const kBumpTimeSeconds2 = 0.1;
 
 //%%% give this a view and an initial count (0 hides the notification circle)
 // and it will make a hub for you
-- (void)setView:(UIView *)view andCount:(int)startCount
+- (void)setView:(UIView *)view andCount:(NSUInteger)startCount
 {
     curOrderMagnitude = 0;
 
@@ -95,7 +94,7 @@ static CGFloat const kBumpTimeSeconds2 = 0.1;
     
     countLabel = [[UILabel alloc]initWithFrame:redCircle.frame];
     countLabel.userInteractionEnabled = NO;
-    [self setCount:startCount];
+    self.count = startCount;
     [countLabel setTextAlignment:NSTextAlignmentCenter];
     countLabel.textColor = [UIColor whiteColor];
     
@@ -169,48 +168,48 @@ static CGFloat const kBumpTimeSeconds2 = 0.1;
 //%%% increases count by 1
 - (void)increment
 {
-    [self setCount:count+1];
+    [self incrementBy:1];
 }
 
 //%%% increases count by amount
-- (void)incrementBy:(int)amount
+- (void)incrementBy:(NSUInteger)amount
 {
-    [self setCount:count+amount];
+    self.count += amount;
 }
 
 //%%% decreases count
 - (void)decrement
 {
-    if (count == 0) {
-        return;
-    }
-    [self setCount:count-1];
+    [self decrementBy:1];
 }
 
 //%%% decreases count by amount
-- (void)decrementBy:(int)amount
+- (void)decrementBy:(NSUInteger)amount
 {
-    [self setCount:count-amount];
+    if (amount >= self.count) {
+        self.count = 0;
+    }
+    self.count -= amount;
 }
 
 //%%% set the count yourself
-- (void)setCount:(int)newCount
+- (void)setCount:(NSUInteger)newCount
 {
-    count = newCount;
-    countLabel.text = [NSString stringWithFormat:@"%i",count];
+    _count = newCount;
+    countLabel.text = [NSString stringWithFormat:@"%@", @(self.count)];
     [self checkZero];
     [self expandToFitLargerDigits];
-}
-
-- (int)count
-{
-    return count;
 }
 
 //%% set the font of the label
 - (void)setCountLabelFont:(UIFont *)font
 {
     [countLabel setFont:[UIFont fontWithName:font.fontName size:redCircle.frame.size.width/2]];
+}
+
+- (UIFont *)countLabelFont
+{
+    return countLabel.font;
 }
 
 #pragma mark - ANIMATION
@@ -367,7 +366,7 @@ static CGFloat const kBumpTimeSeconds2 = 0.1;
 //%%% hides the notification if the value is 0
 - (void)checkZero
 {
-    if (count <= 0) {
+    if (self.count <= 0) {
         redCircle.hidden = YES;
         countLabel.hidden = YES;
     } else {
@@ -379,7 +378,7 @@ static CGFloat const kBumpTimeSeconds2 = 0.1;
 }
 
 - (void)expandToFitLargerDigits {
-    int orderOfMagnitude = log10((double)count);
+    int orderOfMagnitude = log10((double)self.count);
     orderOfMagnitude = (orderOfMagnitude >= 2) ? orderOfMagnitude : 1;
     CGRect frame = initialFrame;
     frame.size.width = initialFrame.size.width * (1 + kCountMagnitudeAdaptationRatio * (orderOfMagnitude - 1));

--- a/RKNotificationHub/RKNotificationHub.m
+++ b/RKNotificationHub/RKNotificationHub.m
@@ -10,22 +10,22 @@
 #import <QuartzCore/QuartzCore.h>
 
 //%%% default diameter
-CGFloat kDefaultDiameter = 30;
-CGFloat kCountMagnitudeAdaptationRatio = 0.3;
+CGFloat const RKNotificationHubDefaultDiameter = 30;
+static CGFloat const kCountMagnitudeAdaptationRatio = 0.3;
 //%%% pop values
-CGFloat kPopStartRatio = .85;
-CGFloat kPopOutRatio = 1.05;
-CGFloat kPopInRatio = .95;
+static CGFloat const kPopStartRatio = .85;
+static CGFloat const kPopOutRatio = 1.05;
+static CGFloat const kPopInRatio = .95;
 
 //%%% blink values
-CGFloat kBlinkDuration = 0.1;
-CGFloat kBlinkAlpha = 0.1;
+static CGFloat const kBlinkDuration = 0.1;
+static CGFloat const kBlinkAlpha = 0.1;
 
 //%%% bump values
-CGFloat kFirstBumpDistance = 8.0;
-CGFloat kBumpTimeSeconds = 0.13;
-CGFloat SECOND_BUMP_DIST = 4.0;
-CGFloat kBumpTimeSeconds2 = 0.1;
+static CGFloat const kFirstBumpDistance = 8.0;
+static CGFloat const kBumpTimeSeconds = 0.13;
+static CGFloat const SECOND_BUMP_DIST = 4.0;
+static CGFloat const kBumpTimeSeconds2 = 0.1;
 
 @interface RKView : UIView
 @property (nonatomic) BOOL isUserChangingBackgroundColor;
@@ -99,7 +99,7 @@ CGFloat kBumpTimeSeconds2 = 0.1;
     [countLabel setTextAlignment:NSTextAlignmentCenter];
     countLabel.textColor = [UIColor whiteColor];
     
-    [self setCircleAtFrame:CGRectMake(frame.size.width- (kDefaultDiameter*2/3), -kDefaultDiameter/3, kDefaultDiameter, kDefaultDiameter)];
+    [self setCircleAtFrame:CGRectMake(frame.size.width- (RKNotificationHubDefaultDiameter*2/3), -RKNotificationHubDefaultDiameter/3, RKNotificationHubDefaultDiameter, RKNotificationHubDefaultDiameter)];
     
     [view addSubview:redCircle];
     [view addSubview:countLabel];


### PR DESCRIPTION
This makes `count` an `@property` of type `NSUInteger`, which is a more typical Objective-C type.  This precludes negative values for `count`, so the decrement method was modified accordingly.  This also makes most of the internal constants `static` so that they don't enter the global linker namespace and `const` so that the compiler knows they are constants.  The default diameter is exported, made `const`, and prefixed to avoid naming collisions.