### PR TITLE
iOS 6 Compatibility

### DIFF
--- a/RKNotificationHub.podspec
+++ b/RKNotificationHub.podspec
@@ -49,7 +49,7 @@ s.social_media_url   = "http://twitter.com/cwrichardkim"
 #
 
 # s.platform     = :ios
-s.platform     = :ios, "7.0"
+s.platform     = :ios, "6.0"
 
 #  When using multiple platforms
 # s.ios.deployment_target = "5.0"

--- a/RKNotificationHub/RKNotificationHub.m
+++ b/RKNotificationHub/RKNotificationHub.m
@@ -97,6 +97,7 @@ static CGFloat const kBumpTimeSeconds2 = 0.1;
     self.count = startCount;
     [countLabel setTextAlignment:NSTextAlignmentCenter];
     countLabel.textColor = [UIColor whiteColor];
+    countLabel.backgroundColor = [UIColor clearColor];
     
     [self setCircleAtFrame:CGRectMake(frame.size.width- (RKNotificationHubDefaultDiameter*2/3), -RKNotificationHubDefaultDiameter/3, RKNotificationHubDefaultDiameter, RKNotificationHubDefaultDiameter)];
     


### PR DESCRIPTION
Fixed the display issue that the label's default white background will cover the whole red circle.
Changed the s.platform to 6.0 since it is working on iOS 6. In this way this library can be integrated to those project with 6.0 deployment target using CocoaPods.